### PR TITLE
[BBB-68] 회원가입 API 연결

### DIFF
--- a/src/apis/auth.ts
+++ b/src/apis/auth.ts
@@ -31,11 +31,15 @@ export const getRefresh = async (refreshToken: string) => {
 };
 
 export const postUser = async (snsType: TSns, formData: FormData) => {
-  const response = await publicInstance.post(`/members/${snsType}`, formData, {
-    headers: {
-      'Content-Type': 'multipart/form-data',
-    },
-  });
+  const response = await publicInstance.post(
+    `/members/${snsType.toUpperCase()}`,
+    formData,
+    {
+      headers: {
+        'Content-Type': 'multipart/form-data',
+      },
+    }
+  );
 
   return response.data;
 };

--- a/src/components/signup/step/2.tsx
+++ b/src/components/signup/step/2.tsx
@@ -1,3 +1,4 @@
+import { useRouter } from 'next/router';
 import { useEffect, useState } from 'react';
 
 import Button from '@/components/common/Button';
@@ -23,6 +24,9 @@ interface IProps {
 }
 
 const SignupStep2 = ({ handleChangeStep }: IProps) => {
+  const router = useRouter();
+  const { id } = router.query;
+
   const [file, setFile] = useState<File | null>(null);
   const [nickname, setNickname] = useState('');
   const [hasDuplicatedNickname, setHasDuplicatedNickname] = useState(false);
@@ -59,7 +63,10 @@ const SignupStep2 = ({ handleChangeStep }: IProps) => {
   });
 
   // 가입 완료
-  const { mutate: signup } = useSignup({ handleChangeStep });
+  const { mutate: signup } = useSignup({
+    snsType: id as TSns,
+    handleChangeStep,
+  });
 
   const handleSubmit = () => {
     if (!isEnabledSubmitButton) return;

--- a/src/components/signup/step/2.tsx
+++ b/src/components/signup/step/2.tsx
@@ -71,10 +71,14 @@ const SignupStep2 = ({ handleChangeStep }: IProps) => {
   const handleSubmit = () => {
     if (!isEnabledSubmitButton) return;
 
+    const request = {
+      nickname,
+      oauthToken: getItem('@oauthToken'),
+    };
+
     const formData = new FormData();
     formData.append('file', file);
-    formData.append('nickname', nickname);
-    formData.append('oauthToken', getItem('@oauthToken')!);
+    formData.append('request', JSON.stringify(request));
     // interests.forEach((interest) => {
     //   formData.append('interests', interest);
     // });

--- a/src/hooks/queries/auth.ts
+++ b/src/hooks/queries/auth.ts
@@ -21,6 +21,7 @@ interface IServeNicknameProps {
 }
 
 interface ISignupProps {
+  snsType: TSns;
   handleChangeStep: (step: number) => void;
 }
 
@@ -118,9 +119,9 @@ const useServeNickname = ({ setNickname }: IServeNicknameProps) => {
   });
 };
 
-export const useSignup = ({ handleChangeStep }: ISignupProps) => {
+export const useSignup = ({ snsType, handleChangeStep }: ISignupProps) => {
   return useMutation({
-    mutationFn: (formData: FormData) => postUser('KAKAO', formData),
+    mutationFn: (formData: FormData) => postUser(snsType, formData),
     onSuccess: ({ code }) => {
       if (code === 'OK') {
         handleChangeStep(2);

--- a/src/hooks/queries/auth.ts
+++ b/src/hooks/queries/auth.ts
@@ -42,7 +42,7 @@ const useSocialLogin = ({
       authCode: string;
     }) => await login(snsType, authCode),
     onSuccess: successCallback,
-    onError: (error: unknown) => {
+    onError: (error: unknown, { snsType }) => {
       if (error instanceof Error && 'response' in error) {
         const axiosError = error as any;
         const status = axiosError.response?.status;
@@ -57,7 +57,7 @@ const useSocialLogin = ({
             console.error('가입되지 않은 회원입니다');
             const oauthToken = axiosError.response?.data?.data;
             setItem('@oauthToken', oauthToken);
-            router.push('/signup');
+            router.push(`/signup/${snsType}`);
             break;
           }
           case 500:

--- a/src/pages/signup/[id].tsx
+++ b/src/pages/signup/[id].tsx
@@ -6,7 +6,7 @@ import SignupStep2 from '@/components/signup/step/2';
 import SignupStep3 from '@/components/signup/step/3';
 import { SIGNUP_PROCESS_STEPS } from '@/constants/signup';
 
-import { css } from '../../styled-system/css';
+import { css } from '../../../styled-system/css';
 
 const SignupPage = () => {
   const [currentStep, setCurrentStep] = useState(0);


### PR DESCRIPTION
### 🔍️ 개요

> 작업 목적을 설명해주세요.

- 회원가입 API 연결

<br></br>

### 🔖 작업 내용

> 주요 변경 사항에 대해 설명해주세요.

- 로그인 401 에러 시 `/signup/:snsType` 으로 리다이렉트
- 회원가입 요청 데이터 수정

<br></br>

### 💬 리뷰어에게

> 리뷰가 필요한 사항 등

- 회원가입 api 요청 시 snsType이 필요하여 로그인 401 에러 시 파라미터에 담아 리다이렉트 시켜줬습니다.
- 백엔드분과 테스트 한 결과 회원가입은 성공했는데, 카카오 인증 쪽 문제가 있어서 카카오 회원가입은 현재도 불가능한 상태입니다! 백엔드에서 테스트용으로 전달해준 구글 토큰 사용하여 회원가입 성공 확인했습니다.

<br></br>

### 📝 참고 사항

> 필요한 경우 피그마나 GIF 등 첨부

<br></br>